### PR TITLE
Build from alpine instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 ADD /binaries/monitoror-linux-amd64-${VERSION} /bin/monitoror
 RUN chmod +x /bin/monitoror
 
-FROM scratch
-COPY --from=builder /bin/monitoror /bin/monitoror
+# FROM scratch
+# COPY --from=builder /bin/monitoror /bin/monitoror
 EXPOSE 8080
 CMD [ "/bin/monitoror" ]


### PR DESCRIPTION
Due to DNS issues with scratch.